### PR TITLE
contrib: rsync_project: avoid "--rsh" for rsync when using default port

### DIFF
--- a/fabric/contrib/project.py
+++ b/fabric/contrib/project.py
@@ -115,7 +115,9 @@ def rsync_project(
         key_string = "-i " + " -i ".join(keys)
     # Port
     user, host, port = normalize(env.host_string)
-    port_string = "-p %s" % port
+    port_string = ""
+    if port != env.default_port:
+        port_string = "-p %s" % port
     # RSH
     rsh_string = ""
     if env.gateway is None:


### PR DESCRIPTION
fix for fabric/fabric#1242