### PR TITLE
switch paramiko dependency to paramiko-ng

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,17 @@ Old Changelog: https://ploxiln.github.io/fab-classic/old_changelog.html
 
 For a quick command reference, run ``fab --help``
 
+Starting with version 1.16 (not yet released), *fab-classic* depends on
+`paramiko-ng <https://github.com/ploxiln/paramiko-ng/>`_ instead of
+`paramiko <https://github.com/paramiko/paramiko/>`_. Both of those packages
+are imported with the name ``paramiko``, and unfortunately that means that you
+should make sure you uninstall *paramiko* before *paramiko-ng* is installed
+(which can happen while installing *fab-classic* from git master), or else
+*paramiko-ng* will not really be installed, even though *pip* thinks it is.
+(Stuff will still use original *paramiko* and work, but you may want
+*paramiko-ng* and will have to uninstall **both** before installing
+*paramiko-ng* actually works.)
+
 ------
 
 fab-classic provides a basic suite of operations for executing local or remote shell
@@ -62,5 +73,5 @@ servers, like so::
 
 In addition to use via the ``fab`` tool, Fabric's components may be imported
 into other Python code, providing a Pythonic interface to the SSH protocol
-suite at a higher level than that provided by e.g. the ``Paramiko`` library
+suite at a higher level than that provided by the ``paramiko-ng`` library
 (which Fabric itself uses).

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(),
     test_suite='nose.collector',
     tests_require=['nose<2.0', 'fudge<1.0', 'jinja2<3.0'],
-    install_requires=['paramiko>=2.0,<3.0', 'six>=1.10.0'],
+    install_requires=['paramiko-ng', 'six>=1.10.0'],
     entry_points={
         'console_scripts': [
             'fab = fabric.main:main',


### PR DESCRIPTION
What's a bit awkward is that you _really_ want to pip uninstall paramiko before pip installs _paramiko-ng_. Otherwise _paramiko-ng_ doesn't correctly install, and old paramiko is still used, and then when you later uninstall old paramiko it's like neither is installed, until you re-install _paramiko-ng_ ...