### PR TITLE
docs: remove versionadded/versionchanged up to 1.1

### DIFF
--- a/fabric/colors.py
+++ b/fabric/colors.py
@@ -1,6 +1,4 @@
 """
-.. versionadded:: 0.9.2
-
 Functions for wrapping strings in ANSI color codes.
 
 Each function within this module returns the input string ``text``, wrapped

--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -295,10 +295,6 @@ def cd(path):
         Space characters will be escaped automatically to make dealing with
         such directory names easier.
 
-    .. versionchanged:: 1.0
-        Applies to `get` and `put` in addition to the command-running
-        operations.
-
     .. seealso:: `~fabric.context_managers.lcd`
     """
     return _change_cwd('cwd', path)
@@ -319,8 +315,6 @@ def lcd(path):
     <http://docs.python.org/release/2.6/library/os.html#os.getcwd>`_. It may be
     useful to pin things relative to the location of the fabfile in use, which
     may be found in :ref:`env.real_fabfile <real-fabfile>`
-
-    .. versionadded:: 1.0
     """
     return _change_cwd('lcwd', path)
 
@@ -353,14 +347,11 @@ def path(path, behavior='append'):
       ``PATH=<path>``.
 
     .. note::
-
         This context manager is currently implemented by modifying (and, as
         always, restoring afterwards) the current value of environment
         variables, ``env.path`` and ``env.path_behavior``. However, this
         implementation may change in the future, so we do not recommend
         manually altering them directly.
-
-    .. versionadded:: 1.0
     """
     return _setenv({'path': path, 'path_behavior': behavior})
 

--- a/fabric/contrib/django.py
+++ b/fabric/contrib/django.py
@@ -1,6 +1,4 @@
 """
-.. versionadded:: 0.9.2
-
 These functions streamline the process of initializing Django's settings module
 environment variable. Once this is done, your fabfile may import from your
 Django project, or Django itself, without requiring the use of ``manage.py``

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -105,12 +105,12 @@ def upload_template(filename, destination, context=None, use_jinja=False,
     Jinja2 Environment which is False by default, same as Jinja2's
     behaviour.
 
-    .. versionchanged:: 1.1
-        Added the ``backup``, ``mirror_local_mode`` and ``mode`` kwargs.
     .. versionchanged:: 1.9
         Added the ``pty`` kwarg.
+
     .. versionchanged:: 1.11
         Added the ``keep_trailing_newline`` kwarg.
+
     .. versionchanged:: 1.11
         Added the  ``temp_dir`` kwarg.
     """
@@ -205,8 +205,6 @@ def sed(filename, before, after, limit='', use_sudo=False, backup='.bak',
     ``flags="i"``. The ``g`` flag is always specified regardless, so you do not
     need to remember to include it when overriding this parameter.
 
-    .. versionadded:: 1.1
-        The ``flags`` parameter.
     .. versionadded:: 1.6
         Added the ``shell`` keyword argument.
     """
@@ -357,16 +355,16 @@ def contains(filename, text, exact=False, use_sudo=False, escape=True,
 
     If ``case_sensitive`` is False, the `-i` flag will be passed to ``egrep``.
 
-    .. versionchanged:: 1.0
-        Swapped the order of the ``filename`` and ``text`` arguments to be
-        consistent with other functions in this module.
     .. versionchanged:: 1.4
         Updated the regular expression related escaping to try and solve
         various corner cases.
+
     .. versionchanged:: 1.4
         Added ``escape`` keyword argument.
+
     .. versionadded:: 1.6
         Added the ``shell`` keyword argument.
+
     .. versionadded:: 1.11
         Added the ``case_sensitive`` keyword argument.
     """
@@ -406,16 +404,10 @@ def append(filename, text, use_sudo=False, partial=False, escape=True,
     The ``shell`` argument will be eventually passed to ``run/sudo``. See
     description of the same argument in `~fabric.contrib.files.sed` for details.
 
-    .. versionchanged:: 0.9.1
-        Added the ``partial`` keyword argument.
-    .. versionchanged:: 1.0
-        Swapped the order of the ``filename`` and ``text`` arguments to be
-        consistent with other functions in this module.
-    .. versionchanged:: 1.0
-        Changed default value of ``partial`` kwarg to be ``False``.
     .. versionchanged:: 1.4
         Updated the regular expression related escaping to try and solve
         various corner cases.
+
     .. versionadded:: 1.6
         Added the ``shell`` keyword argument.
     """

--- a/fabric/contrib/project.py
+++ b/fabric/contrib/project.py
@@ -96,8 +96,10 @@ def rsync_project(
 
     .. versionadded:: 1.4.0
         The ``ssh_opts`` keyword argument.
+
     .. versionadded:: 1.4.1
         The ``capture`` keyword argument.
+
     .. versionadded:: 1.8.0
         The ``default_opts`` keyword argument.
     """
@@ -180,9 +182,6 @@ def upload_project(local_dir=None, remote_dir="", use_sudo=False):
     thus it will not work too well on Win32 systems unless one is using Cygwin
     or something similar. It will attempt to clean up the local and remote
     tarfiles when it finishes executing, even in the event of a failure.
-
-    .. versionchanged:: 1.1
-        Added the ``local_dir`` and ``remote_dir`` kwargs.
 
     .. versionchanged:: 1.7
         Added the ``use_sudo`` kwarg.

--- a/fabric/decorators.py
+++ b/fabric/decorators.py
@@ -83,10 +83,6 @@ def hosts(*host_list):
 
     Note that this decorator actually just sets the function's ``.hosts``
     attribute, which is then read prior to executing the function.
-
-    .. versionchanged:: 0.9.2
-        Allow a single, iterable argument (``@hosts(iterable)``) to be used
-        instead of requiring ``@hosts(*iterable)``.
     """
     return _list_annotating_decorator('hosts', *host_list)
 
@@ -113,10 +109,6 @@ def roles(*role_list):
     invoked with either an argument list or a single, iterable argument.
     Similarly, this decorator uses the same mechanism as
     `~fabric.decorators.hosts` and simply sets ``<function>.roles``.
-
-    .. versionchanged:: 0.9.2
-        Allow a single, iterable argument to be used (same as
-        `~fabric.decorators.hosts`).
     """
     return _list_annotating_decorator('roles', *role_list)
 
@@ -210,7 +202,6 @@ def with_settings(*arg_settings, **kw_settings):
             ...
 
     .. seealso:: `~fabric.context_managers.settings`
-    .. versionadded:: 1.1
     """
     def outer(func):
         @wraps(func)

--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -85,9 +85,6 @@ def require(*keys, **kwargs):
     Note: it is assumed that the keyword arguments apply to all given keys as a
     group. If you feel the need to specify more than one ``used_for``, for
     example, you should break your logic into multiple calls to ``require()``.
-
-    .. versionchanged:: 1.1
-        Allow iterable ``provided_by`` values instead of just single values.
     """
     # If all keys exist and are non-empty, we're good, so keep going.
     missing_keys = [
@@ -323,20 +320,10 @@ def put(local_path=None, remote_path=None, use_sudo=False,
         If a file-like object such as StringIO has a ``name`` attribute, that
         will be used in Fabric's printed output instead of the default
         ``<file obj>``
-    .. versionchanged:: 1.0
-        Now honors the remote working directory as manipulated by
-        `~fabric.context_managers.cd`, and the local working directory as
-        manipulated by `~fabric.context_managers.lcd`.
-    .. versionchanged:: 1.0
-        Now allows file-like objects in the ``local_path`` argument.
-    .. versionchanged:: 1.0
-        Directories may be specified in the ``local_path`` argument and will
-        trigger recursive uploads.
-    .. versionchanged:: 1.0
-        Return value is now an iterable of uploaded remote file paths which
-        also exhibits the ``.failed`` and ``.succeeded`` attributes.
+
     .. versionchanged:: 1.5
         Allow a ``name`` attribute on file-like objects for log output
+
     .. versionchanged:: 1.7
         Added ``use_glob`` option to allow disabling of globbing.
     """
@@ -506,21 +493,6 @@ def get(remote_path, local_path=None, use_sudo=False, temp_dir=""):
         will be used in Fabric's printed output instead of the default
         ``<file obj>``
 
-    .. versionchanged:: 1.0
-        Now honors the remote working directory as manipulated by
-        `~fabric.context_managers.cd`, and the local working directory as
-        manipulated by `~fabric.context_managers.lcd`.
-    .. versionchanged:: 1.0
-        Now allows file-like objects in the ``local_path`` argument.
-    .. versionchanged:: 1.0
-        ``local_path`` may now contain interpolated path- and host-related
-        variables.
-    .. versionchanged:: 1.0
-        Directories may be specified in the ``remote_path`` argument and will
-        trigger recursive downloads.
-    .. versionchanged:: 1.0
-        Return value is now an iterable of downloaded local file paths, which
-        also exhibits the ``.failed`` and ``.succeeded`` attributes.
     .. versionchanged:: 1.5
         Allow a ``name`` attribute on file-like objects for log output
     """
@@ -880,8 +852,6 @@ def open_shell(command=None):
 
     Thus, this function does not have a return value and will not trigger
     Fabric's failure handling if any remote programs result in errors.
-
-    .. versionadded:: 1.0
     """
     _execute(channel=default_channel(), command=command, pty=True,
         combine_stderr=True, invoke_shell=True)
@@ -1059,18 +1029,6 @@ def run(command, shell=True, pty=True, combine_stderr=None, quiet=False,
         output = run('ls /var/www/site1')
         run("take_a_long_time", timeout=5)
 
-    .. versionadded:: 1.0
-        The ``succeeded`` and ``stderr`` return value attributes, the
-        ``combine_stderr`` kwarg, and interactive behavior.
-
-    .. versionchanged:: 1.0
-        The default value of ``pty`` is now ``True``.
-
-    .. versionchanged:: 1.0.2
-        The default value of ``combine_stderr`` is now ``None`` instead of
-        ``True``. However, the default *behavior* is unchanged, as the global
-        setting is still ``True``.
-
     .. versionadded:: 1.5
         The ``quiet``, ``warn_only``, ``stdout`` and ``stderr`` kwargs.
 
@@ -1123,9 +1081,6 @@ def sudo(command, shell=True, pty=True, combine_stderr=None, user=None,
         result = sudo("ls /tmp/")
         with settings(sudo_user='mysql'):
             sudo("whoami") # prints 'mysql'
-
-    .. versionchanged:: 1.0
-        See the changed and added notes for `~fabric.operations.run`.
 
     .. versionchanged:: 1.5
         Now honors :ref:`env.sudo_user <sudo_user>`.
@@ -1190,12 +1145,6 @@ def local(command, capture=False, shell=None, pty=True):
     independently of the remote end (which honors
     `~fabric.context_managers.cd`).
 
-    .. versionchanged:: 1.0
-        Added the ``succeeded`` and ``stderr`` attributes.
-    .. versionchanged:: 1.0
-        Now honors the `~fabric.context_managers.lcd` context manager.
-    .. versionchanged:: 1.0
-        Changed the default value of ``capture`` from ``True`` to ``False``.
     .. versionadded:: 1.9
         The return value attributes ``.command`` and ``.real_command``.
 
@@ -1269,21 +1218,16 @@ def reboot(wait=120, command='reboot', use_sudo=True):
     for at least ``wait`` seconds.
 
     .. note::
-        As of Fabric 1.4, the ability to reconnect partway through a session no
-        longer requires use of internal APIs.  While we are not officially
-        deprecating this function, adding more features to it will not be a
-        priority.
-
         Users who want greater control
         are encouraged to check out this function's (6 lines long, well
         commented) source code and write their own adaptation using different
         timeout/attempt values or additional logic.
 
-    .. versionadded:: 0.9.2
     .. versionchanged:: 1.4
         Changed the ``wait`` kwarg to be optional, and refactored to leverage
         the new reconnection functionality; it may not actually have to wait
         for ``wait`` seconds before reconnecting.
+
     .. versionchanged:: 1.11
         Added ``use_sudo`` as a kwarg. Maintained old functionality by setting
         the default value to True.

--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -1198,6 +1198,9 @@ def local(command, capture=False, shell=None, pty=True):
         Changed the default value of ``capture`` from ``True`` to ``False``.
     .. versionadded:: 1.9
         The return value attributes ``.command`` and ``.real_command``.
+
+    .. versionadded:: 1.15
+        The ``pty`` argument.
     """
     given_command = command
     # Apply cd(), path() etc

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -71,8 +71,6 @@ class Task(object):
     For details on how to implement and use `~fabric.tasks.Task` subclasses,
     please see the usage documentation on :ref:`new-style tasks
     <new-style-tasks>`.
-
-    .. versionadded:: 1.1
     """
     name = 'undefined'
     use_task_objects = True
@@ -145,8 +143,6 @@ class WrappedCallableTask(Task):
     Wraps a given callable transparently, while marking it as a valid Task.
 
     Generally used via `~fabric.decorators.task` and not directly.
-
-    .. versionadded:: 1.1
 
     .. seealso:: `~fabric.docs.unwrap_tasks`, `~fabric.decorators.task`
     """
@@ -316,6 +312,7 @@ def execute(task, *args, **kwargs):
         and some examples.
 
     .. versionadded:: 1.3
+
     .. versionchanged:: 1.4
         Added the return value mapping; previously this function had no defined
         return value.

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -132,7 +132,6 @@ def puts(text, show_prefix=None, end="\n", flush=False):
     You may force output flushing (e.g. to bypass output buffering) by setting
     ``flush=True``.
 
-    .. versionadded:: 0.9.2
     .. seealso:: `~fabric.utils.fastprint`
     """
     from fabric.state import output, env
@@ -167,7 +166,6 @@ def fastprint(text, show_prefix=False, end="", flush=True):
         likewise subject to the ``user`` :doc:`output level
         </usage/output_controls>`.
 
-    .. versionadded:: 0.9.2
     .. seealso:: `~fabric.utils.puts`
     """
     return puts(text=text, show_prefix=show_prefix, end=end, flush=flush)

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -5,6 +5,7 @@ or performing indenting on multiline output.
 import os
 import six
 import sys
+import struct
 import textwrap
 from traceback import format_exc
 
@@ -288,15 +289,13 @@ def _pty_size():
     Defaults to 80x24 (which is also the 'ssh' lib's default) but will detect
     local (stdout-based) terminal window size on non-Windows platforms.
     """
-    from fabric.state import win32
-    if not win32:
-        import fcntl
-        import termios
-        import struct
+    win32 = (sys.platform == 'win32')
 
     default_rows, default_cols = 24, 80
     rows, cols = default_rows, default_cols
     if not win32 and isatty(sys.stdout):
+        import fcntl
+        import termios
         # We want two short unsigned integers (rows, cols)
         fmt = 'HH'
         # Create an empty (zeroed) buffer for ioctl to map onto. Yay for C!

--- a/sites/docs/usage/env.rst
+++ b/sites/docs/usage/env.rst
@@ -139,9 +139,7 @@ as password prompts, "What host to connect to?" prompts, fabfile invocation of
 session will always terminate cleanly instead of blocking on user input forever
 when unforeseen circumstances arise.
 
-.. versionadded:: 1.1
 .. seealso:: :option:`--abort-on-prompts`
-
 
 ``all_hosts``
 -------------
@@ -164,7 +162,6 @@ When set to ``False``, causes `~fabric.operations.run`/`~fabric.operations.sudo`
 to act as if they have been called with ``pty=False``.
 
 .. seealso:: :option:`--no-pty`
-.. versionadded:: 1.0
 
 .. _colorize-errors:
 
@@ -189,8 +186,6 @@ Causes the SSH layer to merge a remote program's stdout and stderr streams to
 avoid becoming meshed together when printed. See :ref:`combine_streams` for
 details on why this is needed and what its effects are.
 
-.. versionadded:: 1.0
-
 ``command``
 -----------
 
@@ -210,8 +205,6 @@ only.
 
 Modified by `~fabric.context_managers.prefix`, and prepended to commands
 executed by `~fabric.operations.run`/`~fabric.operations.sudo`.
-
-.. versionadded:: 1.0
 
 .. _command-timeout:
 
@@ -315,8 +308,6 @@ informational purposes only.
 
 Specifies a list of host strings to be :ref:`skipped over <exclude-hosts>`
 during ``fab`` execution. Typically set via :option:`--exclude-hosts/-x <-x>`.
-
-.. versionadded:: 1.1
 
 
 ``fabfile``
@@ -429,8 +420,6 @@ SSH config option ``ServerAliveInterval``. Useful if you find connections are
 timing out due to meddlesome network hardware or what have you.
 
 .. seealso:: :option:`--keepalive`
-.. versionadded:: 1.1
-
 
 .. _key:
 
@@ -446,7 +435,6 @@ authentication.
     The most common method for using SSH keys is to set :ref:`key-filename`.
 
 .. versionadded:: 1.7
-
 
 .. _key-filename:
 
@@ -477,7 +465,6 @@ if ``parallel`` is True then linewise behavior will occur.
 
 .. versionadded:: 1.3
 
-
 .. _local-user:
 
 ``local_user``
@@ -498,7 +485,6 @@ contain the same value.
 If ``True``, will tell the SSH layer not to seek out running SSH agents when
 using key-based authentication.
 
-.. versionadded:: 0.9.1
 .. seealso:: :option:`--no_agent <-a>`
 
 .. _no_keys:
@@ -512,7 +498,6 @@ If ``True``, will tell the SSH layer not to load any private key files from
 one's ``$HOME/.ssh/`` folder. (Key files explicitly loaded via ``fab -i`` will
 still be used, of course.)
 
-.. versionadded:: 0.9.1
 .. seealso:: :option:`-k`
 
 .. _output_prefix:
@@ -525,8 +510,6 @@ still be used, of course.)
 By default Fabric prefixes every line of output with either ``[hostname] out:``
 or ``[hostname] err:``. Those prefixes may be hidden by setting
 ``env.output_prefix`` to ``False``.
-
-.. versionadded:: 1.0.0
 
 .. _env-parallel:
 
@@ -571,9 +554,6 @@ per-host-string password cache. Keys are full :ref:`host strings
 
 .. seealso:: :ref:`password-management`
 
-.. versionadded:: 1.0
-
-
 .. _env-path:
 
 ``path``
@@ -585,9 +565,6 @@ Used to set the ``$PATH`` shell environment variable when executing commands in
 `~fabric.operations.run`/`~fabric.operations.sudo`/`~fabric.operations.local`.
 It is recommended to use the `~fabric.context_managers.path` context manager
 for managing this value instead of setting it directly.
-
-.. versionadded:: 1.0
-
 
 .. _pool-size:
 

--- a/sites/docs/usage/execution.rst
+++ b/sites/docs/usage/execution.rst
@@ -160,9 +160,6 @@ calling e.g. ``fab --list``.)
 Use of roles is not required in any way -- it's simply a convenience in
 situations where you have common groupings of servers.
 
-.. versionchanged:: 0.9.2
-    Added ability to use callables as ``roledefs`` values.
-
 .. _host-lists:
 
 How host lists are constructed

--- a/sites/docs/usage/fab.rst
+++ b/sites/docs/usage/fab.rst
@@ -30,8 +30,6 @@ tasks.
 Arbitrary remote shell commands
 ===============================
 
-.. versionadded:: 0.9.2
-
 Fabric leverages a lesser-known command line convention and may be called in
 the following manner::
 
@@ -88,8 +86,6 @@ below.
     Sets :ref:`env.no_agent <no_agent>` to ``True``, forcing our SSH layer not
     to talk to the SSH agent when trying to unlock private key files.
 
-    .. versionadded:: 0.9.1
-
 .. cmdoption:: -A, --forward-agent
 
     Sets :ref:`env.forward_agent <forward-agent>` to ``True``, enabling agent
@@ -101,8 +97,6 @@ below.
 
     Sets :ref:`env.abort_on_prompts <abort-on-prompts>` to ``True``, forcing
     Fabric to abort whenever it would prompt for input.
-
-    .. versionadded:: 1.1
 
 .. cmdoption:: -c RCFILE, --config=RCFILE
 
@@ -146,7 +140,6 @@ below.
     omitting this option entirely (i.e. the default), and ``nested`` prints out
     a nested namespace tree.
 
-    .. versionadded:: 1.1
     .. seealso:: :option:`--shortlist`, :option:`--list <-l>`
 
 .. cmdoption:: -g HOST, --gateway=HOST
@@ -197,8 +190,6 @@ below.
     Sets :ref:`env.exclude_hosts <exclude-hosts>` to the given comma-delimited
     list of host strings to then keep out of the final host list.
 
-    .. versionadded:: 1.1
-
 .. cmdoption:: -i KEY_FILENAME
 
     When set to a file path, will load the given file as an SSH identity file
@@ -234,13 +225,9 @@ below.
     Sets :ref:`env.no_keys <no_keys>` to ``True``, forcing the SSH layer to not
     look for SSH private key files in one's home directory.
 
-    .. versionadded:: 0.9.1
-
 .. cmdoption:: --keepalive=KEEPALIVE
 
     Sets :ref:`env.keepalive <keepalive>` to the given (integer) value, specifying an SSH keepalive interval.
-
-    .. versionadded:: 1.1
 
 .. cmdoption:: --linewise
 
@@ -254,8 +241,6 @@ below.
     and exits. Will also print the first line of each task's docstring, if it
     has one, next to it (truncating if necessary.)
 
-    .. versionchanged:: 0.9.1
-        Added docstring to output.
     .. seealso:: :option:`--shortlist`, :option:`--list-format <-F>`
 
 .. cmdoption:: -p PASSWORD, --password=PASSWORD
@@ -281,8 +266,6 @@ below.
     Sets :ref:`env.always_use_pty <always-use-pty>` to ``False``, causing all
     `~fabric.operations.run`/`~fabric.operations.sudo` calls to behave as if
     one had specified ``pty=False``.
-
-    .. versionadded:: 1.0
 
 .. cmdoption:: -r, --reject-unknown-hosts
 
@@ -325,7 +308,6 @@ below.
     Similar to :option:`--list <-l>`, but without any embellishment, just task
     names separated by newlines with no indentation or docstrings.
 
-    .. versionadded:: 0.9.2
     .. seealso:: :option:`--list <-l>`
 
 .. cmdoption:: --show=LEVELS

--- a/sites/docs/usage/fabfiles.rst
+++ b/sites/docs/usage/fabfiles.rst
@@ -42,9 +42,6 @@ When in this mode, tilde-expansion will be applied, so one may refer to e.g.
     fabfile's containing folder to the Python load path (and removes it
     immediately afterwards.)
 
-.. versionchanged:: 0.9.2
-    The ability to load package fabfiles.
-
 
 .. _importing-the-api:
 

--- a/sites/docs/usage/output_controls.rst
+++ b/sites/docs/usage/output_controls.rst
@@ -53,12 +53,6 @@ The standard, atomic output levels/groups are as follows:
 * **user**: User-generated output, i.e. local output printed by fabfile code
   via use of the `~fabric.utils.fastprint` or `~fabric.utils.puts` functions.
   
-.. versionchanged:: 0.9.2
-    Added "Executing task" lines to the ``running`` output level.
-
-.. versionchanged:: 0.9.2
-    Added the ``user`` output level.
-
 Debug output
 ------------
 
@@ -97,9 +91,6 @@ separately.
 * **exceptions**: Enables display of tracebacks when exceptions occur; intended
   for use when ``debug`` is set to ``False`` but one is still interested in
   detailed error info.
-
-.. versionchanged:: 1.0
-    Debug output now includes full Python tracebacks during aborts.
 
 .. versionchanged:: 1.11
     Added the ``exceptions`` output level.


### PR DESCRIPTION
version 1.1 was in 2011 - no one has used a version that old in many years, so the "versionadded" / "versionchanged" notes from that and previous releases are no longer useful or interesting

also add versionadded note for new `pty` argument for `local()`

also clean up some imports a bit