### PR TITLE
setup: PARAMIKO_REPLACE=1 env var trick

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,12 @@ should make sure you uninstall *paramiko* before *paramiko-ng* is installed,
 or you will get strange issues (even if things seem to work at first).
 So, if upgrading, please first run: ``pip uninstall paramiko``
 
+Starting with version 1.18, you can switch back to depending on the package
+named *paramiko* by setting the environment variable ``PARAMIKO_REPLACE=1``
+while installing *fab-classic*::
+
+    PARAMIKO_REPLACE=1 pip install --no-binary fab-classic fab-classic==1.17.9b2
+
 
 Documentation
 -------------

--- a/fabric/version.py
+++ b/fabric/version.py
@@ -7,7 +7,7 @@ which in turn needs access to this version information.)
 """
 
 
-VERSION = (1, 17, 1, 'alpha', 1)
+VERSION = (1, 17, 9, 'beta', 2)
 
 
 def git_sha():

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
-from setuptools import setup, find_packages
+import os
+from setuptools import setup
 
 from fabric.version import get_version
 
 
 long_description = open("README.rst").read()
 
+# set PARAMIKO_REPLACE=1 to require "paramiko" instead of "paramiko-ng"
+paramiko = 'paramiko' if os.environ.get('PARAMIKO_REPLACE') else 'paramiko-ng'
 
 setup(
     name='fab-classic',
@@ -17,8 +20,8 @@ setup(
     maintainer='Pierce Lopez',
     maintainer_email='pierce.lopez@gmail.com',
     url='https://github.com/ploxiln/fab-classic',
-    packages=find_packages(),
-    install_requires=['paramiko-ng', 'six>=1.10.0'],
+    packages=['fabric', 'fabric.contrib'],
+    install_requires=[paramiko, 'six>=1.10.0'],
     entry_points={
         'console_scripts': [
             'fab = fabric.main:main',


### PR DESCRIPTION
to require "paramiko" instead of "paramiko-ng"

... works with the same env var functionality in paramiko-ng
(which causes it to install as "paramiko" instead)