### PR TITLE
tests: use sys.executable instead of "python" for subprocess test

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -465,7 +465,7 @@ def get(remote_path, local_path=None, use_sudo=False, temp_dir=None):
         file named ``access.log``, not ``var/log/apache2/access.log``.
 
         This behavior is intended to be consistent with the command-line
-        ``scp`` program.
+        ``scp`` program (but sftp is always used for the transfer).
 
     If left blank, ``local_path`` defaults to ``"%(host)s/%(path)s"`` in order
     to be safe for multi-host invocations.

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -242,7 +242,7 @@ class _AliasDict(_AttributeDict):
     state, reading aliases is not supported -- only writing to them is allowed.
     This also means they will not show up in e.g. ``dict.keys()``.
 
-    ..note::
+    .. note::
 
         Aliases are recursive, so you may refer to an alias within the key list
         of another alias. Naturally, this means that you can end up with

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,7 +92,7 @@ def test_abort_message_only_printed_once():
     # perform when they are allowed to bubble all the way to the top. So, we
     # invoke a subprocess and look at its stderr instead.
     with quiet():
-        result = local("python -m fabric.__main__ -f tests/support/aborts.py kaboom", capture=True)
+        result = local(sys.executable + " -m fabric.__main__ -f tests/support/aborts.py kaboom", capture=True)
     # When error in #1318 is present, this has an extra "It burns!" at end of
     # stderr string.
     eq_(result.stderr, "Fatal error: It burns!\n\nAborting.")


### PR DESCRIPTION
some environments may have just "python3",
or "python" may be a different python

inspired by https://github.com/fabric/fabric/pull/2086