### PR TITLE
run: change stdin-based pty disable logic (1.17 branch)

### DIFF
--- a/fabric/io.py
+++ b/fabric/io.py
@@ -272,7 +272,7 @@ def input_loop(chan, f, using_pty):
         if byte:
             chan.sendall(byte)
             # Optionally echo locally, if needed.
-            if not using_pty and is_stdin and env.echo_stdin:
+            if (not using_pty) and is_stdin and env.echo_stdin:
                 # Not using fastprint() here -- it prints as 'user'
                 # output level, don't want it to be accidentally hidden
                 sys.stdout.write(byte)

--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -23,7 +23,7 @@ from fabric.sftp import SFTP
 from fabric.state import env, connections, output, win32, default_channel
 from fabric.thread_handling import ThreadHandler
 from fabric.utils import (
-    abort, error, handle_prompt_abort, indent, _pty_size, warn, apply_lcwd, isatty
+    abort, error, handle_prompt_abort, indent, _pty_size, warn, apply_lcwd,
 )
 
 
@@ -727,7 +727,7 @@ def _execute(channel, command, pty=True, combine_stderr=None,
 
     # Assume pty use, and allow overriding of this either via kwarg or env
     # var.  (invoke_shell always wants a pty no matter what.)
-    using_pty = invoke_shell or (pty and env.always_use_pty and isatty(stdin))
+    using_pty = invoke_shell or (pty and env.always_use_pty and (stdin is sys.stdin))
 
     # What to do with CTRl-C?
     remote_interrupt = env.remote_interrupt


### PR DESCRIPTION
this was recently changed to disable pty when command stdin
is not a tty in https://github.com/ploxiln/fab-classic/pull/23

instead, disable pty when command stdin is not process stdin

this gives better backwards compatibility, by always leaving pty
enabled by default, when user does not specify a non-default stdin