### PR TITLE
fix error() output for local() with capture=True

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -1241,7 +1241,10 @@ def local(command, capture=False, shell=None, pty=True, encoding='utf-8'):
     if p.returncode not in env.ok_ret_codes:
         out.failed = True
         msg = "local() encountered an error (return code %s) while executing '%s'" % (p.returncode, command)
-        error(message=msg, stdout=out, stderr=err)
+        # error() assumes the caller has already printed stdout/stderr if they are not hidden,
+        # but that is not true for local() with capture=True, so fudge it so error() includes them
+        with settings(hide('stdout', 'stderr') if capture else None):
+            error(message=msg, stdout=out, stderr=err)
     out.succeeded = not out.failed
     # If we were capturing, this will be a string; otherwise it will be None.
     return out

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -5,7 +5,7 @@ import sys
 import shutil
 
 import six
-from nose.tools import ok_, raises
+from nose.tools import ok_, raises, assert_raises
 from fudge import patched_context, with_fakes, Fake
 from fudge.inspector import arg as fudge_arg
 from mock_streams import mock_streams
@@ -1112,6 +1112,15 @@ def test_local_output_and_capture():
                         capture, stdout, stderr
                     )
                     yield case
+
+def test_local_captured_error_includes_output():
+    with assert_raises(SystemExit) as cm:
+        # list something that will exist '/' along with something that won't
+        # so that we will have output in stdout as well as stderr
+        local('ls / thisfiledoesnotexist', capture=True)
+    ex = cm.exception
+    assert_contains('Standard output', ex.message)
+    assert_contains('Standard error', ex.message)
 
 def test_local_encoding():
     for octstr, encoding, expected in [


### PR DESCRIPTION
error() would assume that stdout/stderr were already printed
if they were not hidden, but that is not true for
local(... capture=True), so make sure error() includes
stderr/stdout in this special case

port of https://github.com/fabric/fabric/pull/2155