### PR TITLE
Optimize _endswith to not instantiate collections

### DIFF
--- a/fabric/io.py
+++ b/fabric/io.py
@@ -18,9 +18,14 @@ if win32:
 
 
 def _endswith(char_list, substring):
-    tail = list(char_list)[-1 * len(substring):]
-    substring = list(substring)
-    return tail == substring
+    if len(substring) > len(char_list):
+        return False
+
+    for i in range(len(substring)):
+        if char_list[-1 - i] != substring[-1 - i]:
+            return False
+
+    return True
 
 
 def _has_newline(bytelist):


### PR DESCRIPTION
fab-classic deals with large amounts of output poorly as the output continues to build. This can cause minutes worth of slowdown for a command that only took seconds to execute.

Through some profiling and troubleshooting, it was discovered `_endswith` is the primary culprit of this because it instantiates a new list object from the self.capture buffer as part of the main loop, which is very time consuming and happens for every line of output.

The proposed patch simply optimizes the check to manually check individual indexes, but results in _massive_ performance improvements for our use case.