### PR TITLE
cleanup some more legacy support bits

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,9 +21,9 @@ jobs:
           - 3.9-bullseye
           - 3.10-bullseye
         paramiko_ver:
-          - 2.5.0
-          - 2.7.8
-          - 2.8.4
+          - 2.6.4
+          - 2.7.10
+          - 2.8.8
     container: "python:${{matrix.imgtag}}"
     steps:
       - uses: actions/checkout@v2

--- a/fabric/network.py
+++ b/fabric/network.py
@@ -11,23 +11,11 @@ import six
 import socket
 import sys
 
+import paramiko as ssh
+
 from fabric.auth import get_password, set_password
 from fabric.utils import handle_prompt_abort, warn
 from fabric.exceptions import NetworkError
-
-try:
-    import warnings
-    warnings.simplefilter('ignore', DeprecationWarning)
-    import paramiko as ssh
-except ImportError:
-    import traceback
-    traceback.print_exc()
-    msg = """
-There was a problem importing our SSH library (see traceback above).
-Please make sure all dependencies are installed and importable.
-""".rstrip()
-    sys.stderr.write(msg + '\n')
-    sys.exit(1)
 
 
 ipv6_regex = re.compile(

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -6,7 +6,9 @@ import os
 import sys
 from optparse import make_option
 
-from fabric.network import HostConnectionCache, ssh
+import paramiko as ssh
+
+from fabric.network import HostConnectionCache
 from fabric.version import get_version
 from fabric.utils import _AliasDict, _AttributeDict
 

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -11,26 +11,6 @@ from fabric.job_queue import JobQueue
 from fabric.task_utils import crawl, merge, parse_kwargs
 from fabric.exceptions import NetworkError
 
-if sys.version_info[:2] == (2, 5):
-    # Python 2.5 inspect.getargspec returns a tuple
-    # instead of ArgSpec namedtuple.
-    class ArgSpec(object):
-        def __init__(self, args, varargs, keywords, defaults):
-            self.args = args
-            self.varargs = varargs
-            self.keywords = keywords
-            self.defaults = defaults
-            self._tuple = (args, varargs, keywords, defaults)
-
-        def __getitem__(self, idx):
-            return self._tuple[idx]
-
-    def patched_get_argspec(func):
-        return ArgSpec(*inspect._getargspec(func))
-
-    inspect._getargspec = inspect.getargspec
-    inspect.getargspec = patched_get_argspec
-
 
 def get_task_details(task):
     details = [
@@ -39,7 +19,7 @@ def get_task_details(task):
         else 'No docstring provided']
     argspec = inspect.getargspec(task)
 
-    default_args = [] if not argspec.defaults else argspec.defaults
+    default_args = argspec.defaults or ()
     num_default_args = len(default_args)
     args_without_defaults = argspec.args[:len(argspec.args) - num_default_args]
     args_with_defaults = argspec.args[-1 * num_default_args:]
@@ -78,8 +58,7 @@ class Task(object):
     is_default = False
 
     # TODO: make it so that this wraps other decorators as expected
-    def __init__(self, alias=None, aliases=None, default=False, name=None,
-        *args, **kwargs):
+    def __init__(self, alias=None, aliases=None, default=False, name=None, *args, **kwargs):
         if alias is not None:
             self.aliases = [alias, ]
         if aliases is not None:


### PR DESCRIPTION
remove support for python-2.5 inspect.getargspec()

remove custom check/message for paramiko import (was more relevant before pip was ubiquitous)