### PR TITLE
contrib: rsync_project: fix "exclude" arg type handling for python3

### DIFF
--- a/fabric/contrib/project.py
+++ b/fabric/contrib/project.py
@@ -5,6 +5,8 @@ from os import getcwd, sep
 import os.path
 from tempfile import mkdtemp
 
+import six
+
 from fabric.network import needs_host, key_filenames, normalize
 from fabric.operations import local, run, sudo, put
 from fabric.state import env, output
@@ -104,7 +106,7 @@ def rsync_project(
         The ``default_opts`` keyword argument.
     """
     # Turn single-string exclude into a one-item list for consistency
-    if not hasattr(exclude, '__iter__'):
+    if isinstance(exclude, six.string_types):
         exclude = (exclude,)
     # Create --exclude options from exclude list
     exclude_opts = ' --exclude "%s"' * len(exclude)

--- a/integration/test_contrib.py
+++ b/integration/test_contrib.py
@@ -117,6 +117,22 @@ class TestRsync(Integration):
         for x in rsync_sources:
             assert not re.search(r'^%s$' % x, r.stdout, re.M), "'%s' was found in '%s'" % (x, r.stdout)
 
+    def test_exclude(self):
+        x = 'integration/utils.py'
+        r = self.rsync(3, exclude=x)
+        lines = r.stdout.splitlines()
+        assert x not in lines, "'%s' was found in '%s'" % (x, r.stdout)
+        x = 'integration/test_contrib.py'
+        assert x in lines, "'%s' was not found in '%s'" % (x, r.stdout)
+
+        arr = ('integration/utils.py', 'integration/test_contrib.py')
+        r = self.rsync(4, exclude=arr)
+        lines = r.stdout.splitlines()
+        x = 'integration/utils.py'
+        assert x not in lines, "'%s' was found in '%s'" % (x, r.stdout)
+        x = 'integration/test_contrib.py'
+        assert x not in lines, "'%s' was found in '%s'" % (x, r.stdout)
+
 
 class TestUploadTemplate(FileCleaner):
     def test_allows_pty_disable(self):


### PR DESCRIPTION
strings also have `__iter__` method in python3,
so just check for string type

fixes https://github.com/ploxiln/fab-classic/issues/66