### PR TITLE
Minor Python 3.x improvements

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -33,11 +33,13 @@ if six.PY2 is True:
 else:
     from contextlib import ExitStack
 
-    class nested(ExitStack):
-        def __init__(self, *managers):
-            super(nested, self).__init__()
-            for manager in managers:
-                self.enter_context(manager)
+    @contextmanager
+    def nested(*contexts):
+        """Reimplementation of nested in Python 3."""
+        with ExitStack() as stack:
+            for ctx in contexts:
+                stack.enter_context(ctx)
+            yield contexts
 
 
 if not win32:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,7 @@
 from fudge import Fake, patched_context, with_fakes
 import unittest
 from nose.tools import raises, ok_
+import six
 import random
 import sys
 
@@ -195,7 +196,7 @@ def dict_contains(superset, subset):
     """
     Assert that all key/val pairs in dict 'subset' also exist in 'superset'
     """
-    for key, value in subset.iteritems():
+    for key, value in six.iteritems(subset):
         ok_(key in superset)
         eq_(superset[key], value)
 


### PR DESCRIPTION
This PR makes two small changes:

### [Implement nested using contextmanager](https://github.com/ploxiln/fab-classic/commit/a8a1e8661e5d501bdd165dd47ca6be88ce20c9bd)
A reimplementation of nested for Python 3 from 43cdd22, using the already imported contextmanager from contextlib.

This should silence linter warnings about the implementation method, but also be Python 3.4+ compatible and more future proof for changes in later Python versions.

### [Fix test_tasks for Python 3](https://github.com/ploxiln/fab-classic/commit/cadc78fbff372fd8e8050724da2c5c2a0be8382b) 

six.iteritems should be used here to ensure identical behaviour between Python 2 and 3.