### PR TITLE
Minor Python 3.5+ improvements

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         imgtag:
-          - 2.7-buster
-          - 3.4-stretch
           - 3.5-buster
           - 3.6-buster
           - 3.7-buster
@@ -30,9 +28,6 @@ jobs:
         run: |
           apt-get -q -y update
           apt-get -q -y install openssh-client openssh-server rsync sudo
-          if [ 3.4-stretch = "${{matrix.imgtag}}" ]; then
-            sed -i -e '/^mesg n/d' /root/.profile
-          fi
       - name: Python dependencies
         run: |
           pip install -r dev-requirements.txt

--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -18,8 +18,7 @@ Context managers for use with the ``with`` statement.
 
 """
 
-from contextlib import contextmanager
-import six
+from contextlib import contextmanager, ExitStack
 import socket
 import select
 
@@ -28,16 +27,12 @@ from fabric.state import output, win32, connections, env
 from fabric import state
 from fabric.utils import isatty
 
-if six.PY2 is True:
-    from contextlib import nested
-else:
-    from contextlib import ExitStack
 
-    class nested(ExitStack):
-        def __init__(self, *managers):
-            super(nested, self).__init__()
-            for manager in managers:
-                self.enter_context(manager)
+class nested(ExitStack):
+    def __init__(self, *managers):
+        super(nested, self).__init__()
+        for manager in managers:
+            self.enter_context(manager)
 
 
 if not win32:
@@ -130,7 +125,7 @@ def _setenv(variables):
     clean_revert = variables.pop('clean_revert', False)
     previous = {}
     new = []
-    for key, value in six.iteritems(variables):
+    for key, value in variables.items():
         if key in state.env:
             previous[key] = state.env[key]
         else:
@@ -140,7 +135,7 @@ def _setenv(variables):
         yield
     finally:
         if clean_revert:
-            for key, value in six.iteritems(variables):
+            for key, value in variables.items():
                 # If the current env value for this key still matches the
                 # value we set it to beforehand, we are OK to revert it to the
                 # pre-block value.

--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -28,11 +28,13 @@ from fabric import state
 from fabric.utils import isatty
 
 
-class nested(ExitStack):
-    def __init__(self, *managers):
-        super(nested, self).__init__()
-        for manager in managers:
-            self.enter_context(manager)
+@contextmanager
+def nested(*contexts):
+    """Reimplementation of nested in Python 3."""
+    with ExitStack() as stack:
+        for ctx in contexts:
+            stack.enter_context(ctx)
+        yield contexts
 
 
 if not win32:

--- a/fabric/contrib/files.py
+++ b/fabric/contrib/files.py
@@ -4,8 +4,7 @@ Module providing easy API for working with remote files and folders.
 
 import hashlib
 import os
-import six
-
+from io import StringIO
 from functools import partial
 
 from fabric.api import run, sudo, hide, settings, env, put, abort
@@ -163,12 +162,12 @@ def upload_template(filename, destination, context=None, use_jinja=False,
         target = destination.replace(' ', r'\ ')
         func("cp %s %s.bak" % (target, target))
 
-    if six.PY3 is True and isinstance(text, bytes):
+    if isinstance(text, bytes):
         text = text.decode('utf-8')
 
     # Upload the file.
     return put(
-        local_path=six.StringIO(text),
+        local_path=StringIO(text),
         remote_path=destination,
         use_sudo=use_sudo,
         mirror_local_mode=mirror_local_mode,
@@ -413,7 +412,7 @@ def append(filename, text, use_sudo=False, partial=False, escape=True,
     """
     func = use_sudo and sudo or run
     # Normalize non-list input to be a list
-    if isinstance(text, six.string_types):
+    if isinstance(text, str):
         text = [text]
     for line in text:
         regex = '^' + _escape_for_regex(line) + ('' if partial else '$')

--- a/fabric/decorators.py
+++ b/fabric/decorators.py
@@ -1,7 +1,6 @@
 """
 Convenience decorators for use in fabfiles.
 """
-import six
 import types
 from functools import wraps
 
@@ -55,7 +54,7 @@ def _list_annotating_decorator(attribute, *values):
             return func(*args, **kwargs)
         _values = values
         # Allow for single iterable argument as well as *args
-        if len(_values) == 1 and not isinstance(_values[0], six.string_types):
+        if len(_values) == 1 and not isinstance(_values[0], str):
             _values = _values[0]
         setattr(inner_decorator, attribute, list(_values))
         # Don't replace @task new-style task objects with inner_decorator by

--- a/fabric/io.py
+++ b/fabric/io.py
@@ -5,8 +5,6 @@ import time
 from select import select
 from collections import deque
 
-import six
-
 from fabric.state import env, output, win32
 from fabric.auth import get_password, set_password
 import fabric.network
@@ -87,7 +85,7 @@ class OutputLooper(object):
                     raise CommandTimeout(timeout=self.timeout)
                 continue
 
-            if six.PY3 is True and isinstance(bytelist, six.binary_type):
+            if isinstance(bytelist, bytes):
                 # Note that we have to decode this right away, even if an error
                 # is thrown only later in the code, because e.g. '' != b'' (see
                 # first if below).
@@ -238,7 +236,7 @@ class OutputLooper(object):
         Iterate through the request prompts dict and return the response and
         original request if we find a match
         """
-        for tup in six.iteritems(env.prompts):
+        for tup in env.prompts.items():
             if _endswith(self.capture, tup[0]):
                 return tup
         return None, None

--- a/fabric/main.py
+++ b/fabric/main.py
@@ -17,8 +17,6 @@ from optparse import OptionParser
 from importlib import import_module
 from collections import Mapping
 
-import six
-
 # For checking callables against the API, & easy mocking
 from fabric import api, state, colors
 from fabric.contrib import console, files, project
@@ -376,7 +374,7 @@ def _is_task(name, value):
 
 def _sift_tasks(mapping):
     tasks, collections = [], []
-    for name, value in six.iteritems(mapping):
+    for name, value in mapping.items():
         if _is_task(name, value):
             tasks.append(name)
         elif isinstance(value, Mapping):
@@ -407,7 +405,7 @@ def _print_docstring(docstrings, name):
     if not docstrings:
         return False
     docstring = crawl(name, state.commands).__doc__
-    if isinstance(docstring, six.string_types):
+    if isinstance(docstring, str):
         return docstring
 
 
@@ -641,7 +639,7 @@ def main(fabfile_locations=None):
         # Handle --hosts, --roles, --exclude-hosts (comma separated string =>
         # list)
         for key in ['hosts', 'roles', 'exclude_hosts']:
-            if key in state.env and isinstance(state.env[key], six.string_types):
+            if key in state.env and isinstance(state.env[key], str):
                 state.env[key] = state.env[key].split(',')
 
         # Feed the env.tasks : tasks that are asked to be executed.

--- a/fabric/network.py
+++ b/fabric/network.py
@@ -7,9 +7,9 @@ import getpass
 import os
 import re
 import time
-import six
 import socket
 import sys
+from io import StringIO
 
 from fabric.auth import get_password, set_password
 from fabric.utils import handle_prompt_abort, warn
@@ -216,7 +216,7 @@ def key_filenames():
     from fabric.state import env
     keys = env.key_filename
     # For ease of use, coerce stringish key filename into list
-    if isinstance(env.key_filename, six.string_types) or env.key_filename is None:
+    if isinstance(env.key_filename, str) or env.key_filename is None:
         keys = [keys]
     # Strip out any empty strings (such as the default value...meh)
     keys = list(filter(bool, keys))
@@ -244,7 +244,7 @@ def key_from_env(passphrase=None):
             if output.debug:
                 sys.stderr.write("Trying to load it as %s\n" % pkey_class)
             try:
-                return pkey_class.from_private_key(six.StringIO(env.key), passphrase)
+                return pkey_class.from_private_key(StringIO(env.key), passphrase)
             except Exception as e:
                 # File is valid key, but is encrypted: raise it, this will
                 # cause cxn loop to prompt for passphrase & retry
@@ -624,10 +624,6 @@ def connect(user, host, port, cache, seek_gateway=True):
 
 
 def _password_prompt(prompt, stream):
-    # NOTE: Using encode-to-ascii to prevent (Windows, at least) getpass from
-    # choking if given Unicode.
-    if six.PY3 is False:
-        prompt = prompt.encode('ascii', 'ignore')
     return getpass.getpass(prompt, stream)
 
 def prompt_for_password(prompt=None, no_colon=False, stream=None):
@@ -690,12 +686,7 @@ def needs_host(func):
             handle_prompt_abort("the target host connection string")
             prompt = "No hosts found. Please specify (single) " \
                 "host string for connection: "
-            # WARNING: do not use six.moves.input, because test cases to not
-            # overwrite that method with a faked method from Fudge
-            if six.PY3 is True:
-                host_string = input(prompt)
-            else:
-                host_string = raw_input(prompt)  # noqa: F821
+            host_string = input(prompt)
             env.update(to_dict(host_string))
         return func(*args, **kwargs)
     host_prompting_wrapper.undecorated = func

--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -7,7 +7,6 @@ import os
 import os.path
 import posixpath
 import re
-import six
 import subprocess
 import sys
 import time
@@ -213,12 +212,7 @@ def prompt(text, key=None, default='', validate=None):
     value = None
     while value is None:
         # Get input
-        # WARNING: do not use six.moves.input, because test cases to not
-        # overwrite that method with a faked method from Fudge
-        if six.PY3 is True:
-            value = input(prompt_str) or default  # noqa: F821
-        else:
-            value = raw_input(prompt_str) or default  # noqa: F821
+        value = input(prompt_str) or default  # noqa: F821
         # Handle validation
         if validate:
             # Callable
@@ -702,7 +696,7 @@ def _prefix_env_vars(command, local=False):
 
         exports = ' '.join(
             '%s%s="%s"' % (set_cmd, k, v if k == 'PATH' else _shell_escape(v))
-            for k, v in six.iteritems(env_vars)
+            for k, v in env_vars.items()
         )
         shell_env_str = '%s%s && ' % (exp_cmd, exports)
     else:
@@ -1225,16 +1219,12 @@ def local(command, capture=False, shell=None, pty=True, encoding='utf-8'):
             dev_null.close()
 
     # Handle error condition (deal with stdout being None, too)
-    if six.PY3:
-        if encoding == "binary":
-            out = _stdoutBytes(stdout or b'')
-            err =              stderr or b''  # noqa: E222
-        else:
-            out = _stdoutString(stdout.decode(encoding).strip() if stdout else "")
-            err =               stderr.decode(encoding).strip() if stderr else ""  # noqa: E222
+    if encoding == "binary":
+        out = _stdoutBytes(stdout or b'')
+        err =              stderr or b''  # noqa: E222
     else:
-        out = _stdoutString(stdout.strip() if stdout else "")
-        err =               stderr.strip() if stderr else ""  # noqa: E222
+        out = _stdoutString(stdout.decode(encoding).strip() if stdout else "")
+        err =               stderr.decode(encoding).strip() if stderr else ""  # noqa: E222
 
     out.command = given_command
     out.real_command = wrapped_command

--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -1,6 +1,5 @@
 import os
 import posixpath
-import six
 import stat
 import re
 import uuid
@@ -253,7 +252,7 @@ class SFTP(object):
         if (local_is_path and mirror_local_mode) or (mode is not None):
             lmode = os.stat(local_path).st_mode if mirror_local_mode else mode
             # Cast to octal integer in case of string
-            if isinstance(lmode, six.string_types):
+            if isinstance(lmode, str):
                 lmode = int(lmode, 8)
             lmode = lmode & int('0o7777', 8)
             rmode = rattrs.st_mode

--- a/fabric/task_utils.py
+++ b/fabric/task_utils.py
@@ -1,4 +1,3 @@
-import six
 from fabric.utils import abort, indent
 from fabric import state
 
@@ -46,7 +45,7 @@ def merge(hosts, roles, exclude, roledefs):
         ))
 
     # Coerce strings to one-item lists
-    if isinstance(hosts, six.string_types):
+    if isinstance(hosts, str):
         hosts = [hosts]
 
     # Look up roles, turn into flat list of hosts
@@ -82,7 +81,7 @@ def parse_kwargs(kwargs):
     hosts = []
     roles = []
     exclude_hosts = []
-    for key, value in six.iteritems(kwargs):
+    for key, value in kwargs.items():
         if key == 'host':
             hosts = [value]
         elif key == 'hosts':

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -1,5 +1,4 @@
 import inspect
-import six
 import sys
 import textwrap
 
@@ -402,7 +401,7 @@ def execute(task, *args, **kwargs):
             # This prevents Fabric from continuing on to any other tasks.
             # Otherwise, pull in results from the child run.
             ran_jobs = jobs.run()
-            for name, d in six.iteritems(ran_jobs):
+            for name, d in ran_jobs.items():
                 if d['exit_code'] != 0:
                     if isinstance(d['results'], NetworkError) and \
                             _is_network_error_ignored():

--- a/fabric/thread_handling.py
+++ b/fabric/thread_handling.py
@@ -1,6 +1,17 @@
 import threading
-import six
 import sys
+
+
+def reraise(tp, value, tb=None):
+    try:
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+    finally:
+        value = None
+        tb = None
 
 
 class ThreadHandler(object):
@@ -23,4 +34,4 @@ class ThreadHandler(object):
     def raise_if_needed(self):
         if self.exception:
             e = self.exception
-            six.reraise(e[0], e[1], e[2])
+            reraise(e[0], e[1], e[2])

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -3,19 +3,10 @@ Internal subroutines for e.g. aborting execution with an error message,
 or performing indenting on multiline output.
 """
 import os
-import six
 import sys
 import struct
 import textwrap
 from traceback import format_exc
-
-
-def _encode(msg, stream):
-    if six.PY2 and isinstance(msg, six.text_type) \
-            and hasattr(stream, 'encoding') and stream.encoding is not None:
-        return msg.encode(stream.encoding)
-    else:
-        return str(msg)
 
 
 def isatty(stream):
@@ -50,7 +41,7 @@ def abort(msg):
         from fabric.colors import red
 
     if output.aborts:
-        sys.stderr.write(red("\nFatal error: %s\n" % _encode(msg, sys.stderr)))
+        sys.stderr.write(red("\nFatal error: %s\n" % msg))
         sys.stderr.write(red("\nAborting.\n"))
 
     if env.abort_exception:
@@ -82,7 +73,6 @@ def warn(msg):
         from fabric.colors import magenta
 
     if output.warnings:
-        msg = _encode(msg, sys.stderr)
         sys.stderr.write(magenta("\nWarning: %s\n\n" % msg))
 
 
@@ -141,7 +131,7 @@ def puts(text, show_prefix=None, end="\n", flush=False):
         prefix = ""
         if env.host_string and show_prefix:
             prefix = "[%s] " % env.host_string
-        sys.stdout.write(prefix + _encode(text, sys.stdout) + end)
+        sys.stdout.write(prefix + str(text) + end)
         if flush:
             sys.stdout.flush()
 

--- a/integration/test_operations.py
+++ b/integration/test_operations.py
@@ -1,9 +1,8 @@
 import os
 import posixpath
 import shutil
-from io import StringIO
+from io import StringIO, BytesIO
 
-from six import BytesIO
 from nose.tools import eq_
 
 from fabric.api import (

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
     maintainer_email='pierce.lopez@gmail.com',
     url='https://github.com/ploxiln/fab-classic',
     packages=['fabric', 'fabric.contrib'],
-    install_requires=[paramiko, 'six>=1.10.0'],
+    python_requires=">=3.5",
+    install_requires=[paramiko + ">=1.17"],
     entry_points={
         'console_scripts': [
             'fab = fabric.main:main',
@@ -37,10 +38,6 @@ setup(
         'Operating System :: Unix',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tests/fake_filesystem.py
+++ b/tests/fake_filesystem.py
@@ -1,14 +1,14 @@
 import os
-import six
 import stat
+from io import StringIO
 
 from fabric.network import ssh
 
 
-class FakeFile(six.StringIO):
+class FakeFile(StringIO):
     def __init__(self, value=None, path=None):
         def init(x):
-            six.StringIO.__init__(self, x)
+            StringIO.__init__(self, x)
 
         if value is None:
             init("")
@@ -28,9 +28,9 @@ class FakeFile(six.StringIO):
         return self.getvalue()
 
     def write(self, value):
-        if six.PY3 is True and isinstance(value, bytes):
+        if isinstance(value, bytes):
             value = value.decode('utf-8')
-        six.StringIO.write(self, value)
+        StringIO.write(self, value)
         self.attributes.st_size = len(self.getvalue())
 
     def close(self):
@@ -40,7 +40,7 @@ class FakeFile(six.StringIO):
         pass
 
     def __cmp__(self, other):
-        me = str(self) if isinstance(other, six.string_types) else self
+        me = str(self) if isinstance(other, str) else self
         return cmp(me, other)  # noqa: F821
 
 
@@ -48,11 +48,11 @@ class FakeFilesystem(dict):
     def __init__(self, d=None):
         # Replicate input dictionary using our custom __setitem__
         d = d or {}
-        for key, value in six.iteritems(d):
+        for key, value in d.items():
             self[key] = value
 
     def __setitem__(self, key, value):
-        if isinstance(value, six.string_types) or value is None:
+        if isinstance(value, str) or value is None:
             value = FakeFile(value, key)
         super(FakeFilesystem, self).__setitem__(key, value)
 

--- a/tests/mock_streams.py
+++ b/tests/mock_streams.py
@@ -2,11 +2,11 @@
 Stand-alone stream mocking decorator for easier imports.
 """
 from functools import wraps
-import six
+from io import StringIO
 import sys
 
 
-class CarbonCopy(six.StringIO):
+class CarbonCopy(StringIO):
     """
     A StringIO capable of multiplexing its writes to other buffer objects.
     """
@@ -17,7 +17,7 @@ class CarbonCopy(six.StringIO):
         it/they will be written to whenever this StringIO instance is written
         to.
         """
-        six.StringIO.__init__(self, buffer)
+        StringIO.__init__(self, buffer)
         if cc is None:
             cc = []
         elif hasattr(cc, 'write'):
@@ -25,7 +25,7 @@ class CarbonCopy(six.StringIO):
         self.cc = cc
 
     def write(self, s):
-        six.StringIO.write(self, s)
+        StringIO.write(self, s)
         for writer in self.cc:
             writer.write(s)
 
@@ -61,11 +61,11 @@ def mock_streams(which):
         @wraps(func)
         def inner_wrapper(*args, **kwargs):
             if both:
-                sys.stdall = six.StringIO()
+                sys.stdall = StringIO()
                 fake_stdout = CarbonCopy(cc=sys.stdall)
                 fake_stderr = CarbonCopy(cc=sys.stdall)
             else:
-                fake_stdout, fake_stderr = six.StringIO(), six.StringIO()
+                fake_stdout, fake_stderr = StringIO(), StringIO()
             if stdout:
                 my_stdout, sys.stdout = sys.stdout, fake_stdout
             if stderr:

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -1,6 +1,6 @@
 import os
-import six
 import sys
+from io import StringIO
 
 from nose.tools import eq_, ok_
 
@@ -254,14 +254,14 @@ class TestQuietAndWarnOnly(FabricTest):
         run("ls /simple")
         ok_(sys.stdout.getvalue())
         # Reset
-        sys.stdout = six.StringIO()
+        sys.stdout = StringIO()
         # Real test
         with quiet():
             run("ls /simple")
         # Empty output
         ok_(not sys.stdout.getvalue())
         # Reset
-        sys.stdout = six.StringIO()
+        sys.stdout = StringIO()
         # Kwarg test
         run("ls /simple", quiet=True)
         ok_(not sys.stdout.getvalue())

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement
 import os
-import six
 
 from fabric.contrib.files import upload_template, contains
 from fabric.context_managers import hide, lcd
@@ -113,8 +111,6 @@ class TestContrib(FabricTest):
             upload_template(template_name, remote, {'first_name': first_name},
                 use_jinja=True, template_dir=template_dir)
             get(remote, local)
-        if six.PY2 is True:
-            first_name = first_name.encode('utf-8')
         eq_contents(local, first_name)
 
     @server()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 import copy
 from collections import Mapping
 from functools import partial
-import six
 import os.path
 import sys
 
@@ -619,7 +618,7 @@ def name_to_task(name):
 
 def strings_to_tasks(d):
     ret = {}
-    for key, value in six.iteritems(d):
+    for key, value in d.items():
         if isinstance(value, Mapping):
             val = strings_to_tasks(value)
         else:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -3,8 +3,8 @@ import os
 import re
 import sys
 import shutil
+from io import StringIO, BytesIO
 
-import six
 from nose.tools import ok_, raises, assert_raises
 from fudge import patched_context, with_fakes, Fake
 from fudge.inspector import arg as fudge_arg
@@ -545,7 +545,7 @@ class TestFileTransfers(FabricTest):
     @mock_streams('stderr')
     def _invalid_file_obj_situations(self, remote_path):
         with settings(hide('running'), warn_only=True):
-            get(remote_path, six.StringIO())
+            get(remote_path, StringIO())
         assert_contains('is a glob or directory', sys.stderr.getvalue())
 
     def test_glob_and_file_object_invalid(self):
@@ -695,7 +695,7 @@ class TestFileTransfers(FabricTest):
         """
         get()'s local_path arg should take file-like objects too
         """
-        fake_file = six.BytesIO()
+        fake_file = BytesIO()
         target = '/file.txt'
         with hide('everything'):
             get(target, fake_file)
@@ -735,7 +735,7 @@ class TestFileTransfers(FabricTest):
         get() should return None if local_path is a StringIO
         """
         with hide('everything'):
-            eq_([], get('/file.txt', six.BytesIO()))
+            eq_([], get('/file.txt', BytesIO()))
 
     @server()
     def test_get_return_value_failed_attribute(self):
@@ -873,7 +873,7 @@ class TestFileTransfers(FabricTest):
         put()'s local_path arg should take file-like objects too
         """
         local = self.path('whatever')
-        fake_file = six.StringIO()
+        fake_file = StringIO()
         fake_file.write("testing file-like objects in put()")
         pointer = fake_file.tell()
         target = '/new_file.txt'
@@ -914,7 +914,7 @@ class TestFileTransfers(FabricTest):
         f = 'uploaded.txt'
         with hide('everything'):
             # '/' is homedir (see FakeFilesystem.normalize())
-            eq_(put(six.StringIO('contents'), f), ['/' + f])
+            eq_(put(StringIO('contents'), f), ['/' + f])
 
     @server()
     def test_put_return_value_failed_attribute(self):
@@ -922,7 +922,7 @@ class TestFileTransfers(FabricTest):
         put()'s return value should indicate any paths which failed to upload.
         """
         with settings(hide('everything'), warn_only=True):
-            f = six.StringIO('contents')
+            f = StringIO('contents')
             retval = put(f, '/nonexistent/directory/structure')
         eq_(["<StringIO>"], retval.failed)
         assert not retval.succeeded
@@ -1074,7 +1074,7 @@ class TestFileTransfers(FabricTest):
     @server()
     @mock_streams('stdout')
     def test_stringio_without_name(self):
-        file_obj = six.StringIO(u'test data')
+        file_obj = StringIO(u'test data')
         put(file_obj, '/')
         assert re.search('<file obj>', sys.stdout.getvalue())
 
@@ -1082,7 +1082,7 @@ class TestFileTransfers(FabricTest):
     @mock_streams('stdout')
     def test_stringio_with_name(self):
         """If a file object (StringIO) has a name attribute, use that in output"""
-        file_obj = six.StringIO(u'test data')
+        file_obj = StringIO(u'test data')
         file_obj.name = 'Test StringIO Object'
         put(file_obj, '/')
         assert re.search(file_obj.name, sys.stdout.getvalue())
@@ -1129,8 +1129,6 @@ def test_local_encoding():
         (r"a\001\002\003", 'binary', b"a\x01\x02\x03"),
     ]:
         res = local("printf '%s'" % octstr, capture=True, encoding=encoding)
-        if six.PY2 and encoding != "binary":
-            res = res.decode(encoding)
         assert res == expected, "%r != %r" % (res, expected)
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -195,7 +195,7 @@ def dict_contains(superset, subset):
     """
     Assert that all key/val pairs in dict 'subset' also exist in 'superset'
     """
-    for key, value in subset.iteritems():
+    for key, value in subset.items():
         ok_(key in superset)
         eq_(superset[key], value)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import sys
 
 from fudge import Fake, patched_context, with_fakes

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,6 @@ import shutil
 import sys
 import tempfile
 
-import six
 from fudge import Fake, patched_context, clear_expectations
 from fudge.patcher import with_patched_object
 from nose.tools import raises
@@ -95,7 +94,7 @@ def password_response(password, times_called=None, silent=True):
     """
     fake = Fake('getpass', callable=True)
     # Assume stringtype or iterable, turn into mutable iterable
-    if isinstance(password, six.string_types):
+    if isinstance(password, str):
         passwords = [password]
     else:
         passwords = list(password)
@@ -213,10 +212,7 @@ def aborts(func):
 
 
 def _patched_input(func, fake):
-    if six.PY3 is True:
-        return func(sys.modules['builtins'], 'input', fake)
-    else:
-        return func(sys.modules['__builtin__'], 'raw_input', fake)
+    return func(sys.modules['builtins'], 'input', fake)
 
 
 patched_input = partial(_patched_input, patched_context)


### PR DESCRIPTION
This PR makes two small changes to the `req_py3` branch:

### [Implement nested using contextmanager](https://github.com/ploxiln/fab-classic/commit/d457d9c20698f7b8355dd2ef644632c8921d52d5)
A reimplementation of nested for Python 3 from 43cdd22, using the already imported contextmanager from contextlib.

This should silence linter warnings about the implementation method, but also be Python 3.4+ compatible and more future proof for changes in later Python versions.

### [Fix test_tasks for Python 3](https://github.com/ploxiln/fab-classic/commit/18a47314510ce33c43a954a15e4691445d45c39e) 

This is a rework of https://github.com/ploxiln/fab-classic/commit/cadc78fbff372fd8e8050724da2c5c2a0be8382b that doesn't use six for Python 3.5+ support.