### PR TITLE
io: fix input channel EOF detection

### DIFF
--- a/fabric/io.py
+++ b/fabric/io.py
@@ -283,7 +283,7 @@ def input_loop(chan, f, using_pty):
                 sys.stdout.write(byte)
                 sys.stdout.flush()
 
-        elif byte == '':  # EOF
+        elif byte == '' and chan.eof_received:  # EOF
             chan.shutdown_write()
             break
         else:


### PR DESCRIPTION
When attempting to use parallel mode along with sudo, fabric was causing paramiko-ng to go into an infinite loop. The reason was due to a combination of fabric calling sendall() along with it misdetecting EOF on the input and closing the output channel. The fix for paramiko-ng going into an infinite loop is here:

https://github.com/ploxiln/paramiko-ng/pull/140

This commit fixes the root cause in fabric where it (apparently) erroneously  detects the input channel as being closed when it is not.