### PR TITLE
Improve server load retry logic

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -499,7 +499,7 @@ def connect(user, host, port, cache, seek_gateway=True):
             #
             # If we are using a gateway, we will get a ChannelException if
             # connection to the downstream host fails. We should retry.
-            if (e.__class__ is ssh.SSHException and msg == 'Error reading SSH protocol banner') \
+            if (e.__class__ is ssh.SSHException and msg.startswith('Error reading SSH protocol banner')) \
                or e.__class__ is ssh.ChannelException:
                 if _tried_enough(tries):
                     raise NetworkError(msg, e)


### PR DESCRIPTION
SSHExceptions caused by protocol banner read errors can have extra text in their message.

fixes #76