### PR TITLE
cleanup import fallbacks now that python-3.6+ required

### DIFF
--- a/fabric/decorators.py
+++ b/fabric/decorators.py
@@ -4,11 +4,6 @@ Convenience decorators for use in fabfiles.
 import types
 from functools import wraps
 
-try:
-    from Crypto import Random
-except ImportError:
-    Random = None
-
 from fabric import tasks
 from .context_managers import settings
 
@@ -167,12 +162,8 @@ def parallel(pool_size=None):
     def real_decorator(func):
         @wraps(func)
         def inner(*args, **kwargs):
-            # Required for ssh/PyCrypto to be happy in multiprocessing
-            # (as far as we can tell, this is needed even with the extra such
-            # calls in newer versions of paramiko.)
-            if Random:
-                Random.atfork()
             return func(*args, **kwargs)
+
         inner.parallel = True
         inner.serial = False
         inner.pool_size = None if called_without_args else pool_size

--- a/fabric/job_queue.py
+++ b/fabric/job_queue.py
@@ -6,10 +6,7 @@ items, though within Fabric itself only ``Process`` objects are used/supported.
 """
 
 import time
-try:
-    import Queue
-except ImportError:
-    import queue as Queue
+import queue as Queue
 from multiprocessing import Process
 
 from fabric.network import ssh

--- a/fabric/main.py
+++ b/fabric/main.py
@@ -15,10 +15,8 @@ import getpass
 import inspect
 from optparse import OptionParser
 from importlib import import_module
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
+from functools import reduce
 
 # For checking callables against the API, & easy mocking
 from fabric import api, state, colors
@@ -29,11 +27,6 @@ from fabric.state import env_options
 from fabric.tasks import Task, execute, get_task_details
 from fabric.task_utils import _Dict, crawl
 from fabric.utils import abort, indent, warn, _pty_size
-
-try:
-    reduce
-except NameError:
-    from functools import reduce
 
 # One-time calculation of "all internal callables" to avoid doing this on every
 # check of a given fabfile callable (in is_classic_task()).

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -324,18 +324,7 @@ def execute(task, *args, **kwargs):
 
     parallel = requires_parallel(task)
     if parallel:
-        # Import multiprocessing if needed, erroring out usefully
-        # if it can't.
-        try:
-            import multiprocessing
-        except ImportError:
-            import traceback
-            tb = traceback.format_exc()
-            abort(tb + """
-    At least one task needs to be run in parallel, but the
-    multiprocessing module cannot be imported (see above
-    traceback.) Please make sure the module is installed
-    or that the above ImportError is fixed.""")
+        import multiprocessing
     else:
         multiprocessing = None
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     url='https://github.com/ploxiln/fab-classic',
     packages=['fabric', 'fabric.contrib'],
     python_requires=">=3.6",
-    install_requires=[paramiko],
+    install_requires=[paramiko + '>=2.0'],
     entry_points={
         'console_scripts': [
             'fab = fabric.main:main',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,10 +2,7 @@ import copy
 from functools import partial
 import os.path
 import sys
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
 
 from fudge import Fake, patched_context
 from nose.tools import ok_, eq_


### PR DESCRIPTION
Also, the custom message for "multiprocessing" ImportError
was not really helpful, so simply import there too.

Also remove PyCrypto atfork() handling: Paramiko switched from PyCrypto to Cryptography in 2.0 a decade ago, so make the 2.x requirement official and remove last bit of PyCrypto