### PR TITLE
fix parallel mode on macOS with python-3.8+

### DIFF
--- a/fabric/job_queue.py
+++ b/fabric/job_queue.py
@@ -7,11 +7,13 @@ items, though within Fabric itself only ``Process`` objects are used/supported.
 
 import time
 import queue as Queue
-from multiprocessing import Process
+from collections import namedtuple
 
 from fabric.network import ssh
 from fabric.context_managers import settings
 
+
+DoneProc = namedtuple('DoneProc', ['name', 'exitcode'])
 
 class JobQueue(object):
     """
@@ -73,7 +75,7 @@ class JobQueue(object):
 
     def append(self, process):
         """
-        Add the Process() to the queue, so that later it can be checked up on.
+        Add the Process to the queue, so that later it can be checked up on.
         That is if the JobQueue is still open.
 
         If the queue is closed, this will just silently do nothing.
@@ -145,12 +147,15 @@ class JobQueue(object):
                         if self._debug:
                             print("Job queue found finished proc: %s." % job.name)
                         done = self._running.pop(id)
-                        self._completed.append((done.name, done.exitcode))
-                        if hasattr(done, 'close') and callable(done.close):
-                            done.close()
-                        # multiprocessing.Process.close() added in Python-3.7
-                        # for older versions of python, GC will have to do
-                        del done
+                        # might be a Process or a Thread
+                        if hasattr(done, 'exitcode'):
+                            proc = done
+                            done = DoneProc(proc.name, proc.exitcode)
+                            # multiprocessing.Process.close() added in Python-3.7
+                            if hasattr(proc, 'close'):
+                                proc.close()
+                            del proc
+                        self._completed.append(done)
 
                 if self._debug:
                     print("Job queue has %d running." % len(self._running))
@@ -174,9 +179,9 @@ class JobQueue(object):
         self._fill_results(results)
 
         # Attach exit codes now that we're all done & have joined all jobs
-        for job_name, exit_code in self._completed:
-            if isinstance(job, Process):
-                results[job_name]['exit_code'] = exit_code
+        for job in self._completed:
+            if hasattr(job, 'exitcode'):
+                results[job.name]['exit_code'] = job.exitcode
 
         return results
 


### PR DESCRIPTION
fab-classic's current implementation of parallel mode depends on multiprocessing using "fork" mode, not "spawn" mode (due to pickle-ability of some objects). Python-3.8 switched the default on macOS from "fork" to "spawn" because macOS system libraries often use threads which can cause instability if forked. In practice, fork usually works fine for fab-classic on macOS, and it's better than always failing or disabling parallel mode.

This situation may affect Linux too starting with Python-3.14 because "spawn" will be the default if there are any threads created, and _paramiko_ uses threads. (In the simplest cases it won't be a problem, because ssh connections will only be made by parallel sub-processes, but you can run multiple tasks where some do not allow parallel-mod ...)

Also fix-up support for Threads mode in `job_queue.py`, even though _fab-classic_ doesn't use it, just to try to keep things working as close to original Fabric-1.x as possible, because I want to avoid re-designs in general, and keep this project on minimal-maintenance mode. This thread/process job_queue thing was a bit mixed-up by cdc597d1fe60 in #74

fixes #27