### PR TITLE
Improve handling of SSH protocol banner read failures

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -507,6 +507,13 @@ def connect(user, host, port, cache, seek_gateway=True):
                or e.__class__ is ssh.ChannelException:
                 if _tried_enough(tries):
                     raise NetworkError(msg, e)
+                # Banner read failures can occur near-instantly (e.g. when a
+                # systemd socket-activated sshd accepts the TCP connection
+                # during shutdown/boot but never starts sshd to send the
+                # banner). Sleep before retrying so we don't burn through
+                # env.connection_attempts in a few seconds -- this keeps
+                # reboot()'s wait=N semantics intact.
+                time.sleep(env.timeout)
                 continue
 
             # For whatever reason, empty password + no ssh key or agent

--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -3,6 +3,7 @@ Functions to be used in fabfiles and other non-core code, such as run()/sudo().
 """
 
 import errno
+import logging
 import os
 import os.path
 import posixpath
@@ -1281,12 +1282,37 @@ def reboot(wait=120, command='reboot', use_sudo=True):
         connection_attempts=attempts
     ):
         (sudo if use_sudo else run)(command)
-        # Try to make sure we don't slip in before pre-reboot lockdown
-        time.sleep(5)
-        # This is actually an internal-ish API call, but users can simply drop
-        # it in real fabfile use -- the next run/sudo/put/get/etc call will
-        # automatically trigger a reconnect.
-        # We use it here to force the reconnect while this function is still in
-        # control and has the above timeout settings enabled.
-        connections.connect(env.host_string)
+        # When a connection attempt fails to read the SSH banner (which is
+        # expected while the host is shutting down or booting, especially
+        # with socket-activated sshd), paramiko's transport thread logs the
+        # error with a full traceback to the 'paramiko.transport' logger,
+        # which surfaces on stderr via logging's last-resort handler. Those
+        # failures are anticipated and handled by the reconnect loop, so
+        # silence that logger while we wait for the host to come back.
+        paramiko_logger = logging.getLogger('paramiko.transport')
+        previous_level = paramiko_logger.level
+        paramiko_logger.setLevel(logging.CRITICAL)
+        try:
+            # Try to make sure we don't slip in before pre-reboot lockdown
+            time.sleep(5)
+            # Drop the dead connection to the now-rebooting host so the
+            # reconnect below starts from a clean slate instead of leaking
+            # the old client.
+            if env.host_string in connections:
+                try:
+                    connections[env.host_string].close()
+                except (OSError, EOFError, ssh.SSHException):
+                    # The transport is already dead because the host is
+                    # shutting down; errors while closing it are expected
+                    # and irrelevant.
+                    pass
+                del connections[env.host_string]
+            # This is actually an internal-ish API call, but users can simply
+            # drop it in real fabfile use -- the next run/sudo/put/get/etc
+            # call will automatically trigger a reconnect.
+            # We use it here to force the reconnect while this function is
+            # still in control and has the above timeout settings enabled.
+            connections.connect(env.host_string)
+        finally:
+            paramiko_logger.setLevel(previous_level)
     # At this point we should be reconnected to the newly rebooted server.

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -247,8 +247,10 @@ class TestNetwork(FabricTest):
         fake_ssh = Fake('ssh', allows_any_call=True)
         fake_ssh.expects('SSHClient').calls(generate_fake_client)
 
-        # We need the real exceptions here to preserve the inheritence structure
-        # and for except clauses because python3 is picky about that
+        # The fake replaces the whole paramiko module as seen by
+        # fabric.network, so the real exception classes must be reattached:
+        # connect() references them in except clauses (which require genuine
+        # exception types) and compares caught exceptions by class.
         fake_ssh.SSHException = ssh.SSHException
         fake_ssh.ChannelException = ssh.ChannelException
         fake_ssh.BadHostKeyException = ssh.BadHostKeyException
@@ -264,6 +266,98 @@ class TestNetwork(FabricTest):
             # Restore ssh
             patched_connect.restore()
             patched_password.restore()
+
+    @with_fakes
+    def test_connect_sleeps_between_banner_error_retries(self):
+        """
+        Banner read errors should sleep env.timeout between retries
+
+        A systemd socket-activated sshd (Ubuntu 24.04+) accepts the TCP
+        connection during shutdown/boot but never sends a banner, so the
+        failure is near-instant. Without a sleep between retries,
+        env.connection_attempts is exhausted in a few seconds, breaking
+        reboot()'s wait=N semantics.
+        """
+        def raise_banner_error_twice(*args, **kwargs):
+            if raise_banner_error_twice.failures_left > 0:
+                raise_banner_error_twice.failures_left -= 1
+                raise ssh.SSHException('Error reading SSH protocol banner')
+        raise_banner_error_twice.failures_left = 2
+
+        def generate_fake_client():
+            fake_client = Fake('SSHClient', allows_any_call=True)
+            fake_client.expects('connect').calls(raise_banner_error_twice)
+            return fake_client
+
+        fake_ssh = Fake('ssh', allows_any_call=True)
+        fake_ssh.expects('SSHClient').calls(generate_fake_client)
+
+        # The fake replaces the whole paramiko module as seen by
+        # fabric.network, so the real exception classes must be reattached:
+        # connect() references them in except clauses (which require genuine
+        # exception types) and compares caught exceptions by class.
+        fake_ssh.SSHException = ssh.SSHException
+        fake_ssh.ChannelException = ssh.ChannelException
+        fake_ssh.BadHostKeyException = ssh.BadHostKeyException
+        fake_ssh.AuthenticationException = ssh.AuthenticationException
+        fake_ssh.PasswordRequiredException = ssh.PasswordRequiredException
+
+        # Expect one sleep of env.timeout per failed attempt that is retried
+        fake_time = Fake('time', allows_any_call=True)
+        fake_time.expects('sleep').with_args(7).times_called(2)
+
+        patched_ssh = patch_object('fabric.network', 'ssh', fake_ssh)
+        patched_time = patch_object('fabric.network', 'time', fake_time)
+        try:
+            with settings(connection_attempts=3, timeout=7):
+                connect('user', 'localhost', 22, HostConnectionCache())
+        finally:
+            # Restore ssh and time
+            patched_ssh.restore()
+            patched_time.restore()
+
+    @with_fakes
+    @raises(NetworkError)
+    def test_connect_gives_up_on_banner_error_after_connection_attempts(self):
+        """
+        Persistent banner read errors should raise NetworkError after
+        env.connection_attempts tries, without sleeping after the final try
+        """
+        def raise_banner_error(*args, **kwargs):
+            raise ssh.SSHException('Error reading SSH protocol banner')
+
+        def generate_fake_client():
+            fake_client = Fake('SSHClient', allows_any_call=True)
+            fake_client.expects('connect').calls(raise_banner_error)
+            return fake_client
+
+        fake_ssh = Fake('ssh', allows_any_call=True)
+        fake_ssh.expects('SSHClient').calls(generate_fake_client)
+
+        # The fake replaces the whole paramiko module as seen by
+        # fabric.network, so the real exception classes must be reattached:
+        # connect() references them in except clauses (which require genuine
+        # exception types) and compares caught exceptions by class.
+        fake_ssh.SSHException = ssh.SSHException
+        fake_ssh.ChannelException = ssh.ChannelException
+        fake_ssh.BadHostKeyException = ssh.BadHostKeyException
+        fake_ssh.AuthenticationException = ssh.AuthenticationException
+        fake_ssh.PasswordRequiredException = ssh.PasswordRequiredException
+
+        # Expect sleeps between the three attempts, but none after the final
+        # attempt, which raises NetworkError instead of retrying
+        fake_time = Fake('time', allows_any_call=True)
+        fake_time.expects('sleep').with_args(7).times_called(2)
+
+        patched_ssh = patch_object('fabric.network', 'ssh', fake_ssh)
+        patched_time = patch_object('fabric.network', 'time', fake_time)
+        try:
+            with settings(connection_attempts=3, timeout=7):
+                connect('user', 'localhost', 22, HostConnectionCache())
+        finally:
+            # Restore ssh and time
+            patched_ssh.restore()
+            patched_time.restore()
 
     @mock_streams('stdout')
     @server()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
 import re
 import sys
@@ -15,7 +16,7 @@ from fabric.state import env
 from fabric.context_managers import nested, settings
 from fabric.operations import require, prompt, _sudo_prefix, _shell_wrap, \
     _shell_escape
-from fabric.api import get, put, hide, show, cd, lcd, local, run, sudo, quiet
+from fabric.api import get, put, hide, show, cd, lcd, local, run, sudo, quiet, reboot
 from fabric.exceptions import CommandTimeout
 from fabric.sftp import SFTP
 
@@ -1160,3 +1161,62 @@ class TestRunSudoReturnValues(FabricTest):
             # Slightly flexible test, we're not testing the actual construction
             # here, just that this attribute exists.
             ok_(env.shell in run("ls /").real_command)
+
+
+#
+# reboot()
+#
+
+class TestReboot(FabricTest):
+    def test_reboot_issues_command_and_reconnects(self):
+        """
+        reboot() should issue the command, drop the stale cached connection,
+        then force a reconnect with retry settings derived from ``wait``
+        """
+        state = {}
+
+        class FakeClient(object):
+            # Stands in for the SSHClient whose transport died when the
+            # host went down; close() raising is the expected case there.
+            def close(self):
+                state['old_client_closed'] = True
+                raise EOFError
+
+        class FakeConnections(dict):
+            # Stands in for state.connections (HostConnectionCache)
+            def connect(self, key):
+                state['reconnected_to'] = key
+                # Capture the temporary settings reboot() reconnects under
+                state['retry_settings'] = (
+                    env.timeout, env.connection_attempts
+                )
+                # paramiko's transport thread logs expected banner errors at
+                # ERROR level; reboot() must silence that during reconnect
+                state['paramiko_errors_silenced'] = not logging.getLogger(
+                    'paramiko.transport').isEnabledFor(logging.ERROR)
+
+        fake_connections = FakeConnections()
+        fake_connections[env.host_string] = FakeClient()
+
+        fake_sudo = Fake('sudo', callable=True).calls(
+            lambda command: state.__setitem__('command', command))
+        # Fake out time so the test doesn't spend 5s in reboot()'s sleep
+        fake_time = Fake('time', allows_any_call=True)
+
+        patched_sudo = patched_context('fabric.operations', 'sudo', fake_sudo)
+        patched_time = patched_context('fabric.operations', 'time', fake_time)
+        patched_connections = patched_context(
+            'fabric.operations', 'connections', fake_connections)
+        with patched_sudo, patched_time, patched_connections:
+            reboot(wait=60)
+
+        eq_(state['command'], 'reboot')
+        eq_(state['old_client_closed'], True)
+        # Stale cache entry must be removed before reconnecting
+        eq_(fake_connections, {})
+        eq_(state['reconnected_to'], env.host_string)
+        # wait=60 with the internal 5s timeout means 12 attempts
+        eq_(state['retry_settings'], (5, 12))
+        eq_(state['paramiko_errors_silenced'], True)
+        # The logger must be re-enabled once reboot() is done
+        ok_(logging.getLogger('paramiko.transport').isEnabledFor(logging.ERROR))


### PR DESCRIPTION
Closes https://github.com/ploxiln/fab-classic/issues/96

`reboot()` failed with `NetworkError: Error reading SSH protocol banner` on Ubuntu 24.04, where sshd is systemd socket-activated (`ssh.socket`). During shutdown, systemd still accepts TCP connections on port 22 but never starts sshd, so each reconnect attempt fails near-instantly with a banner read error instead of a connection refused/timeout. Since the banner-error retry path in `network.connect()` retried with no delay, all of `reboot(wait=N)`'s connection attempts were exhausted within a couple of seconds while the host was still going down.

This change adds a `time.sleep(env.timeout)` between banner-error/ChannelException retries (mirroring the existing socket-error retry behavior), so retries genuinely span the requested `wait` window. In addition, `reboot()` now closes and removes the stale cached connection before forcing the reconnect, and temporarily silences the `paramiko.transport` logger during the reconnect window so expected banner failures no longer dump tracebacks to stderr (the level is restored afterwards). 

Includes new unit tests covering the retry/sleep behavior, the give-up-after-N-attempts case, and `reboot()`'s reconnect handling; verified against a real Ubuntu 24.04 host.